### PR TITLE
Handle malformed automation sensor add events

### DIFF
--- a/custom_components/qolsys_panel/sensor.py
+++ b/custom_components/qolsys_panel/sensor.py
@@ -139,9 +139,18 @@ async def async_setup_entry(
 
     # Add new Automation Device Sensor - Dynamic
     def _automation_device_sensor_add(event: Event) -> None:
-        virtual_node_id = event.data["virtual_node_id"]
-        endpoint = event.data["endpoint"]
-        unit = event.data["unit"]
+        event_data = event.data or {}
+        try:
+            virtual_node_id = event_data["virtual_node_id"]
+            endpoint = event_data["endpoint"]
+            unit = event_data["unit"]
+        except KeyError as err:
+            _LOGGER.warning(
+                "Ignoring automation sensor add event missing %s: %s",
+                err.args[0],
+                event_data,
+            )
+            return
 
         _LOGGER.debug(
             "EVENT_AUTDEV_SENSOR_ADD - virtual_node_id:%s, endpoint:%s, unit:%s",

--- a/test/test_sensor.py
+++ b/test/test_sensor.py
@@ -13,6 +13,7 @@ from qolsys_controller.enum_qolsys import (
     QolsysNotification,
     QolsysSensorScale,
 )
+from qolsys_controller.observable import Event
 
 from custom_components.qolsys_panel.sensor import (
     AutomationDevice_BatteryValue,
@@ -163,12 +164,48 @@ async def test_dynamic_sensor_add(hass: HomeAssistant, controller: MagicMock) ->
         if call.args[0] is QolsysNotification.AUTOMATION_SENSOR_ADD
     )
     callback(
-        virtual_node_id="5",
-        endpoint=0,
-        unit=QolsysSensorScale.TEMPERATURE_FAHRENHEIT,
+        Event(
+            QolsysNotification.AUTOMATION_SENSOR_ADD,
+            controller,
+            {
+                "virtual_node_id": "5",
+                "endpoint": 0,
+                "unit": QolsysSensorScale.TEMPERATURE_FAHRENHEIT,
+            },
+        )
     )
 
     assert add_entities.call_count == 2
+
+
+async def test_dynamic_sensor_add_ignores_missing_virtual_node_id(
+    hass: HomeAssistant, controller: MagicMock
+) -> None:
+    """A malformed dynamic sensor-add notification does not crash setup."""
+    config_entry = MagicMock()
+    config_entry.runtime_data = controller
+    config_entry.unique_id = UID
+    add_entities = MagicMock()
+
+    await async_setup_entry(hass, config_entry, add_entities)
+
+    callback = next(
+        call.args[1]
+        for call in controller.state.register.call_args_list
+        if call.args[0] is QolsysNotification.AUTOMATION_SENSOR_ADD
+    )
+    callback(
+        Event(
+            QolsysNotification.AUTOMATION_SENSOR_ADD,
+            controller,
+            {
+                "endpoint": 0,
+                "unit": QolsysSensorScale.TEMPERATURE_FAHRENHEIT,
+            },
+        )
+    )
+
+    assert add_entities.call_count == 1
 
 
 @pytest.mark.parametrize(("sensor_cls", "attr"), ZONE_SENSORS)


### PR DESCRIPTION
## Summary
- Guard dynamic automation sensor add events against missing payload fields.
- Log and ignore malformed `AUTOMATION_SENSOR_ADD` events instead of raising `KeyError`.
- Add a regression test for a sensor-add event missing `virtual_node_id`.

## Observed Home Assistant Logs
The integration can currently crash its MQTT panel client when a dynamic automation sensor event is missing `virtual_node_id`:

```text
2026-08-03 19:52:47.131 ERROR (MainThread) [qolsys_controller.controller]
MQTT Panel Client - Supervisor detected failure: KeyError('virtual_node_id')

KeyError: 'virtual_node_id'
    virtual_node_id = kwargs["virtual_node_id"]
```

Traceback excerpt:

```text
/config/custom_components/qolsys_panel/sensor.py, line 140, in _automation_device_sensor_add
/usr/local/lib/python3.14/site-packages/qolsys_controller/observable.py
/usr/local/lib/python3.14/site-packages/qolsys_controller/automation/service_sensor.py
/usr/local/lib/python3.14/site-packages/qolsys_controller/automation_zwave/service_sensor.py
/usr/local/lib/python3.14/site-packages/qolsys_controller/automation_zwave/device.py
/usr/local/lib/python3.14/site-packages/qolsys_controller/panel.py
/usr/local/lib/python3.14/site-packages/qolsys_controller/controller.py
```

In my install, this left the thermostat and other devices connected through the panel unavailable.

Mosquitto was running and did not show broker-side error lines at the same time.
